### PR TITLE
feat: initialize Go server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.16-alpine as deploy-builder
+
+WORKDIR /app
+
+RUN apk add --no-cache git
+
+ENV GO111MODULE=on
+
+COPY go.mod .
+COPY go.sum .
+
+COPY . .
+ARG REVISION="default"
+
+RUN go mod download
+
+RUN go build -o server -ldflags "-X main.revision=${REVISION}"
+
+FROM alpine as deploy
+
+COPY --from=deploy-builder /app/server .
+
+CMD ["./server"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/hgsgtk/selenium-proxy-server
+
+go 1.16

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+var (
+	// revision is assumed to be overwritten by the ldflags option.
+	revision = "default"
+)
+
+func main() {
+	// Fixme temporary server implementation
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
```
-> % docker build .
[+] Building 2.1s (16/16) FINISHED                                                                                                               
 => [internal] load build definition from Dockerfile                                                                                        0.0s
 => => transferring dockerfile: 378B                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                           0.0s
 => => transferring context: 2B                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/golang:1.16-alpine                                                                       0.8s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                            0.0s
 => [internal] load build context                                                                                                           0.0s
 => => transferring context: 2.93kB                                                                                                         0.0s
 => CACHED [deploy 1/2] FROM docker.io/library/alpine                                                                                       0.0s
 => [deploy-builder 1/8] FROM docker.io/library/golang:1.16-alpine@sha256:34e3951701d7cc4153ca322933ed82edf8575af0d3f5c40362dca3b3c2bc425e  0.0s
 => CACHED [deploy-builder 2/8] WORKDIR /app                                                                                                0.0s
 => CACHED [deploy-builder 3/8] RUN apk add --no-cache git                                                                                  0.0s
 => CACHED [deploy-builder 4/8] COPY go.mod .                                                                                               0.0s
 => CACHED [deploy-builder 5/8] COPY go.sum .                                                                                               0.0s
 => [deploy-builder 6/8] COPY . .                                                                                                           0.0s
 => [deploy-builder 7/8] RUN go mod download                                                                                                0.3s
 => [deploy-builder 8/8] RUN go build -o server -ldflags "-X main.revision=default"                                                         0.7s
 => [deploy 2/2] COPY --from=deploy-builder /app/server .                                                                                   0.0s
 => exporting to image                                                                                                                      0.0s
 => => exporting layers                                                                                                                     0.0s
 => => writing image sha256:d15d590ab5204cf2384a39d616e65ef3a9e8b4b067e3af0e13ed09fa9c87ccdd                                                0.0s
```

ref: https://hub.docker.com/layers/golang/library/golang/1.16-alpine/images/sha256-1ba55bae768e5b140b78671cfca51167f2eec88463314418f0904a205c34df7c?context=explore

