### PR TITLE
feat: first proxy handler that can handle /proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,18 @@ services:
             - "4444:4444"
         volumes:
             - /dev/shm:/dev/shm
-    
+        networks:
+            selenium-instance:    
+
     selenium-proxy-server:
         build: .
         ports:
             - "8080:8080"
+        depends_on:
+            - selenium-server
+        networks:
+            selenium-instance:
+    
+
+networks:
+    selenium-instance:

--- a/example/go_google.py
+++ b/example/go_google.py
@@ -5,7 +5,7 @@ options = webdriver.ChromeOptions()
 options.add_argument('--headless')
 
 driver = webdriver.Remote(
-    command_executor='http://localhost:4444/wd/hub',
+    command_executor='http://localhost:8080/proxy',
     desired_capabilities=options.to_capabilities(),
     options=options,
 )

--- a/main.go
+++ b/main.go
@@ -2,25 +2,80 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"strings"
+	"time"
 )
 
 var (
 	// revision is assumed to be overwritten by the ldflags option.
 	revision = "default"
+
+	// fixme: set from out of container
+	seleniumServerURL = "http://selenium-server:4444"
 )
 
 func main() {
 	// Fixme split to another file
 	hcHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "{\"releaseId\": %s}", revision)
 	}
 
 	proxyHandler := func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "Hello proxy server")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		defer r.Body.Close()
+
+		reqBodyBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "{\"error\": %s}", err)
+			return
+		}
+
+		// logging request body
+		fmt.Fprintf(os.Stdout, "request method: '%s', body: '%s'\n", r.Method, reqBodyBytes)
+
+		// proxy to selenium server hub endpoint
+		req, err := http.NewRequestWithContext(
+			r.Context(),
+			r.Method,
+			seleniumServerURL+"/wd/hub",
+			strings.NewReader(string(reqBodyBytes)))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "{\"error\": %s}", err)
+			return
+		}
+		client := &http.Client{
+			Timeout: 3 * time.Second,
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "{\"error\": %s}", err)
+			return
+		}
+		resBodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "{\"error\": %s}", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		// logging response body
+		fmt.Fprintf(os.Stdout, "response status: '%d', body: '%s'\n", resp.StatusCode, string(resBodyBytes))
+
+		// response to client
+		w.WriteHeader(resp.StatusCode)
+		fmt.Fprint(w, string(resBodyBytes))
 	}
 
 	http.HandleFunc("/.healthcheck", hcHandler)


### PR DESCRIPTION
Can be it.

```
$ curl http://localhost:8080/proxy
{
  "value": {
    "error": "unknown command",
    "message": "Unable to find handler for (GET) \u002fwd\u002fhub",
    "stacktrace": ""
  }
}
```

logging to stdout.

```
selenium-proxy-server_1  | request method: 'GET', body: ''
selenium-proxy-server_1  | response status: '404', body: '{
selenium-proxy-server_1  |   "value": {
selenium-proxy-server_1  |     "error": "unknown command",
selenium-proxy-server_1  |     "message": "Unable to find handler for (GET) \u002fwd\u002fhub",
selenium-proxy-server_1  |     "stacktrace": ""
selenium-proxy-server_1  |   }
selenium-proxy-server_1  | }'
```